### PR TITLE
Reorganize imports and add App.js for entry point

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,2 @@
+// App.js
+import "expo-router/entry";

--- a/src/modules/users/navigation/TrainersTab.tsx
+++ b/src/modules/users/navigation/TrainersTab.tsx
@@ -12,12 +12,13 @@ import {
 import { useRouter } from "expo-router";
 import { AntDesign, Fontisto, MaterialIcons } from "@expo/vector-icons";
 
+import firestore from "@react-native-firebase/firestore";
+
 import useUserBookings from "@src/modules/users/hooks/booking/useUserBookings";
 import { Booking } from "@server/database/models/Booking";
 import HeadingChips from "@src/modules/users/components/elements/chips/HeadingChips";
 import { COLOR_DARK_BLUE, COLOR_YELLOW } from "@src/modules/common/constants";
 import useRescheduleStore from "@src/modules/re-schedule/store/useRescheduleStore";
-import firestore from "@react-native-firebase/firestore";
 
 function TrainerItem({ item }: { item: Booking }): ReactElement {
   const { push } = useRouter();


### PR DESCRIPTION
Moved `firestore` import to follow the code style and added `App.js` as the entry point using `expo-router`. These changes enhance code readability and ensure proper module initialization.