### PR TITLE
Fix userType assignment in ChatMessageInput

### DIFF
--- a/src/modules/users/components/chat/chatBox/ChatMessageInput.tsx
+++ b/src/modules/users/components/chat/chatBox/ChatMessageInput.tsx
@@ -61,7 +61,7 @@ function ChatMessageInput({
           activity: {
             type: "chat",
             id: chat.id,
-            userType: type.toLowerCase() === "trainer" ? "Trainer" : "User",
+            userType: type.toLowerCase() === "trainer" ? "User" : "Trainer",
           },
         };
         setMessage("");


### PR DESCRIPTION
Corrected the logic for assigning userType in ChatMessageInput component. Previously, trainers were being assigned the type "User" and vice versa, which has now been fixed to reflect the correct assignment.